### PR TITLE
Featural Improvement in Periodic Table Explorer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,23 +1,48 @@
-import React from "react";
+import React, { useState } from "react";
 import PeriodicTable from "./Components/PeriodicTable";
 import Trends from "./Components/Trends/Trends";
 import CompareElements from "./Components/compareElements";
 import ThemeToggle from "./Components/ThemeToggle/ThemeToggle";
 import Assistant from "./Components/Assistant/Assistant";
+import QuizMode from "./Components/QuizMode";
 
 function App() {
+  const [quizOpen, setQuizOpen] = useState(false);
+
   return (
     <div className="app">
       <header className="app-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '1rem 2rem' }}>
         <h1 style={{ margin: 0 }}>Periodic Table Explorer</h1>
-        <ThemeToggle />
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <button
+            onClick={() => setQuizOpen(true)}
+            style={{
+              padding: '8px 16px',
+              borderRadius: '10px',
+              border: '1px solid rgba(167, 139, 250, 0.35)',
+              background: 'linear-gradient(135deg, rgba(139, 92, 246, 0.22), rgba(167, 139, 250, 0.22))',
+              color: '#ddd6fe',
+              fontSize: '14px',
+              fontWeight: '600',
+              cursor: 'pointer',
+              fontFamily: 'Inter, sans-serif',
+              transition: 'all 0.2s ease',
+            }}
+            title="Open Quiz Mode"
+          >
+            ⚗️ Quiz Mode
+          </button>
+          <ThemeToggle />
+        </div>
       </header>
       <PeriodicTable />
       <Trends />
       <CompareElements />
       <Assistant />
+      {quizOpen && <QuizMode onClose={() => setQuizOpen(false)} />}
     </div>
   );
 }
 
 export default App;
+

--- a/src/App.js
+++ b/src/App.js
@@ -6,9 +6,11 @@ import ThemeToggle from "./Components/ThemeToggle/ThemeToggle";
 import Assistant from "./Components/Assistant/Assistant";
 import QuizMode from "./Components/QuizMode";
 
+
 function App() {
   const [quizOpen, setQuizOpen] = useState(false);
 
+  
   return (
     <div className="app">
       <header className="app-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '1rem 2rem' }}>
@@ -28,8 +30,7 @@ function App() {
               fontFamily: 'Inter, sans-serif',
               transition: 'all 0.2s ease',
             }}
-            title="Open Quiz Mode"
-          >
+            title="Open Quiz Mode">
             ⚗️ Quiz Mode
           </button>
           <ThemeToggle />

--- a/src/Components/PeriodicTable.css
+++ b/src/Components/PeriodicTable.css
@@ -194,12 +194,68 @@ position: relative;
   padding: 20px;
 }
 
+/* ===== Element Image ===== */
+.details-image-wrapper {
+  margin-bottom: 16px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.details-element-image {
+  width: 100%;
+  max-height: 200px;
+  object-fit: cover;
+  display: block;
+}
+
+.details-image-caption {
+  margin: 0;
+  padding: 6px 10px;
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.4;
+  font-style: italic;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.details-image-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 100px;
+  margin-bottom: 16px;
+  border-radius: 12px;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.details-image-placeholder-symbol {
+  font-size: 32px;
+  font-weight: 800;
+  color: rgba(255, 255, 255, 0.15);
+}
+
+.details-image-placeholder-text {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* ===== Action Buttons Row ===== */
+.details-actions {
+  display: flex;
+  gap: 8px;
+  margin: 2px 0 14px;
+}
+
 .details-gallery-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
-  margin: 2px 0 14px;
+  flex: 1;
   padding: 10px 14px;
   border-radius: 10px;
   border: 1px solid rgba(59, 130, 246, 0.35);
@@ -217,6 +273,54 @@ position: relative;
   background: linear-gradient(135deg, rgba(59, 130, 246, 0.32), rgba(99, 102, 241, 0.32));
   color: #eff6ff;
   transform: translateY(-1px);
+}
+
+.details-wiki-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(167, 139, 250, 0.35);
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.22), rgba(167, 139, 250, 0.22));
+  color: #ddd6fe;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.details-wiki-btn:hover {
+  border-color: rgba(167, 139, 250, 0.55);
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.32), rgba(167, 139, 250, 0.32));
+  color: #ede9fe;
+  transform: translateY(-1px);
+}
+
+/* ===== Spectral Image ===== */
+.details-spectral {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  margin-bottom: 12px;
+}
+
+.details-spectral-link {
+  font-size: 12px;
+  font-weight: 600;
+  color: #a78bfa;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.details-spectral-link:hover {
+  color: #c4b5fd;
 }
 
 @keyframes overlayFadeIn {

--- a/src/Components/PeriodicTable.css
+++ b/src/Components/PeriodicTable.css
@@ -104,6 +104,23 @@ position: relative;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+}
+
+.element-bg-image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.22;
+  pointer-events: none;
+  border-radius: inherit;
+  transition: opacity 0.3s ease;
+}
+
+.element:hover .element-bg-image {
+  opacity: 0.42;
 }
 
 .element:hover {
@@ -341,11 +358,28 @@ position: relative;
   padding: 28px;
   width: 100%;
   max-width: 420px;
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
   box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5),
     0 0 0 1px rgba(255, 255, 255, 0.05);
   animation: detailsSlideIn 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
   color: #e2e8f0;
   font-family: "Inter", sans-serif;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(167, 139, 250, 0.4) transparent;
+}
+
+.element-details::-webkit-scrollbar {
+  width: 5px;
+}
+
+.element-details::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.element-details::-webkit-scrollbar-thumb {
+  background-color: rgba(167, 139, 250, 0.4);
+  border-radius: 10px;
 }
 
 @keyframes detailsSlideIn {

--- a/src/Components/PeriodicTable.js
+++ b/src/Components/PeriodicTable.js
@@ -311,6 +311,26 @@ const PeriodicTable = () => {
               </div>
             </div>
 
+            {/* Element Image */}
+            {selectedElement.image?.url ? (
+              <div className="details-image-wrapper">
+                <img
+                  src={selectedElement.image.url}
+                  alt={selectedElement.image.title || selectedElement.name}
+                  className="details-element-image"
+                  onError={(e) => { e.currentTarget.style.display = "none"; }}
+                />
+                {selectedElement.image.title && (
+                  <p className="details-image-caption">{selectedElement.image.title}</p>
+                )}
+              </div>
+            ) : (
+              <div className="details-image-placeholder">
+                <span className="details-image-placeholder-symbol">{selectedElement.symbol}</span>
+                <span className="details-image-placeholder-text">No image available</span>
+              </div>
+            )}
+
             <div className="details-grid">
               <div className="detail-item">
                 <span className="detail-label">Atomic Number</span>
@@ -340,6 +360,34 @@ const PeriodicTable = () => {
                 <span className="detail-label">Phase</span>
                 <span className="detail-value">{selectedElement.phase ?? "—"}</span>
               </div>
+              <div className="detail-item">
+                <span className="detail-label">Melting Point</span>
+                <span className="detail-value">
+                  {selectedElement.melt != null ? `${selectedElement.melt} K` : "—"}
+                </span>
+              </div>
+              <div className="detail-item">
+                <span className="detail-label">Boiling Point</span>
+                <span className="detail-value">
+                  {selectedElement.boil != null ? `${selectedElement.boil} K` : "—"}
+                </span>
+              </div>
+              <div className="detail-item">
+                <span className="detail-label">Electron Affinity</span>
+                <span className="detail-value">
+                  {selectedElement.electron_affinity != null
+                    ? `${selectedElement.electron_affinity} kJ/mol`
+                    : "—"}
+                </span>
+              </div>
+              <div className="detail-item">
+                <span className="detail-label">Named By</span>
+                <span className="detail-value">{selectedElement.named_by ?? "—"}</span>
+              </div>
+              <div className="detail-item detail-item-full">
+                <span className="detail-label">Appearance</span>
+                <span className="detail-value">{selectedElement.appearance ?? "—"}</span>
+              </div>
               <div className="detail-item detail-item-full">
                 <span className="detail-label">Discovered by</span>
                 <span className="detail-value">{selectedElement.discovered_by ?? "Unknown"}</span>
@@ -354,14 +402,42 @@ const PeriodicTable = () => {
               )}
             </div>
 
-            <a
-              className="details-gallery-btn"
-              href={getElementGalleryUrl(selectedElement)}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              View {selectedElement.name} Gallery
-            </a>
+            {/* Action buttons */}
+            <div className="details-actions">
+              <a
+                className="details-gallery-btn"
+                href={getElementGalleryUrl(selectedElement)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View Gallery
+              </a>
+              {selectedElement.source && (
+                <a
+                  className="details-wiki-btn"
+                  href={selectedElement.source}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn more on Wikipedia →
+                </a>
+              )}
+            </div>
+
+            {/* Spectral image */}
+            {selectedElement.spectral_img && (
+              <div className="details-spectral">
+                <span className="detail-label">Spectral Image</span>
+                <a
+                  href={selectedElement.spectral_img}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="details-spectral-link"
+                >
+                  View spectral lines →
+                </a>
+              </div>
+            )}
 
             {selectedElement.summary && (
               <p className="details-summary">{selectedElement.summary}</p>

--- a/src/Components/PeriodicTable.js
+++ b/src/Components/PeriodicTable.js
@@ -161,6 +161,15 @@ const PeriodicTable = () => {
         tabIndex={visible ? 0 : -1}
         title={visible ? `${element.name} (${element.symbol}) - #${element.number}` : ""}
       >
+        {element.bohr_model_image && (
+          <img
+            src={element.bohr_model_image}
+            alt=""
+            className="element-bg-image"
+            loading="lazy"
+            aria-hidden="true"
+          />
+        )}
         <strong className={`element-block ${element.block}`}>
           {element.symbol}
         </strong>

--- a/src/Components/PerodicTable.js
+++ b/src/Components/PerodicTable.js
@@ -14,7 +14,6 @@ const PeriodicTable = () => {
     setSelectedElement(element);
   };
 
-
   // Filter Blocks
 
   const mainElements = getMainElements(elementsData);

--- a/src/Components/QuizMode.css
+++ b/src/Components/QuizMode.css
@@ -1,0 +1,297 @@
+/* ===== Quiz Overlay ===== */
+.quiz-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  padding: 20px;
+  animation: quizOverlayIn 0.2s ease;
+}
+
+@keyframes quizOverlayIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ===== Quiz Modal ===== */
+.quiz-modal {
+  position: relative;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.98), rgba(15, 23, 42, 0.99));
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  padding: 28px;
+  width: 100%;
+  max-width: 480px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.05);
+  animation: quizModalIn 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  color: #e2e8f0;
+  font-family: "Inter", sans-serif;
+}
+
+@keyframes quizModalIn {
+  from { opacity: 0; transform: translateY(16px) scale(0.96); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* ===== Header ===== */
+.quiz-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.quiz-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: #f1f5f9;
+  letter-spacing: -0.01em;
+}
+
+.quiz-close-btn {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #94a3b8;
+  transition: all 0.2s ease;
+}
+
+.quiz-close-btn:hover {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: #ef4444;
+}
+
+/* ===== Score Bar ===== */
+.quiz-scorebar {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.quiz-score-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 8px 6px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 10px;
+}
+
+.quiz-score-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #64748b;
+}
+
+.quiz-score-value {
+  font-size: 16px;
+  font-weight: 700;
+  color: #e2e8f0;
+}
+
+.quiz-score-streak {
+  color: #fb923c;
+}
+
+/* ===== Question ===== */
+.quiz-question {
+  font-size: 17px;
+  font-weight: 600;
+  color: #f1f5f9;
+  line-height: 1.5;
+  margin-bottom: 12px;
+  min-height: 52px;
+}
+
+/* ===== Element Chip ===== */
+.quiz-element-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  background: rgba(167, 139, 250, 0.12);
+  border: 1px solid rgba(167, 139, 250, 0.25);
+  border-radius: 20px;
+  margin-bottom: 16px;
+  font-size: 13px;
+}
+
+.quiz-chip-number {
+  color: #94a3b8;
+  font-weight: 600;
+  font-size: 11px;
+}
+
+.quiz-chip-symbol {
+  font-weight: 800;
+  font-size: 15px;
+  color: #c4b5fd;
+}
+
+.quiz-chip-name {
+  color: #94a3b8;
+  font-size: 11px;
+}
+
+/* ===== Options ===== */
+.quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.quiz-option {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: #cbd5e1;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.18s ease;
+  text-align: left;
+  font-family: "Inter", sans-serif;
+}
+
+.quiz-option:not(:disabled):hover {
+  background: rgba(167, 139, 250, 0.15);
+  border-color: rgba(167, 139, 250, 0.3);
+  color: #e2e8f0;
+  transform: translateX(3px);
+}
+
+.quiz-option:disabled {
+  cursor: default;
+}
+
+.quiz-option.correct {
+  background: rgba(34, 197, 94, 0.15);
+  border-color: rgba(34, 197, 94, 0.4);
+  color: #86efac;
+}
+
+.quiz-option.wrong {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.4);
+  color: #fca5a5;
+}
+
+.quiz-option-key {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  font-size: 11px;
+  font-weight: 700;
+  color: #64748b;
+  flex-shrink: 0;
+}
+
+.quiz-option-text {
+  flex: 1;
+}
+
+/* ===== Feedback ===== */
+.quiz-feedback {
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  animation: feedbackPop 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes feedbackPop {
+  from { opacity: 0; transform: scale(0.95); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.feedback-correct {
+  background: rgba(34, 197, 94, 0.12);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  color: #86efac;
+}
+
+.feedback-wrong {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
+}
+
+/* ===== Next Button ===== */
+.quiz-next-btn {
+  width: 100%;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(167, 139, 250, 0.35);
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.25), rgba(167, 139, 250, 0.25));
+  color: #ddd6fe;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: "Inter", sans-serif;
+  letter-spacing: 0.01em;
+}
+
+.quiz-next-btn:not(:disabled):hover {
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.4), rgba(167, 139, 250, 0.4));
+  border-color: rgba(167, 139, 250, 0.55);
+  color: #ede9fe;
+  transform: translateY(-1px);
+}
+
+.quiz-next-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* ===== Hint ===== */
+.quiz-hint {
+  text-align: center;
+  font-size: 11px;
+  color: #475569;
+  margin: 8px 0 0;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 520px) {
+  .quiz-modal {
+    padding: 20px;
+  }
+
+  .quiz-scorebar {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .quiz-question {
+    font-size: 15px;
+  }
+}

--- a/src/Components/QuizMode.js
+++ b/src/Components/QuizMode.js
@@ -1,0 +1,194 @@
+import React, { useState, useCallback, useEffect, useRef } from "react";
+import elementsData from "../Data/elementsData";
+import "./QuizMode.css";
+
+const QUESTION_TYPES = ["symbol-to-name", "name-to-symbol", "number-to-symbol"];
+
+function pickRandom(arr, exclude) {
+  const pool = arr.filter((x) => x !== exclude);
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+function generateQuestion(elements) {
+  const type = QUESTION_TYPES[Math.floor(Math.random() * QUESTION_TYPES.length)];
+  const element = elements[Math.floor(Math.random() * elements.length)];
+
+  // Build 4 unique answer options
+  const correctAnswer =
+    type === "symbol-to-name" ? element.name
+    : type === "name-to-symbol" ? element.symbol
+    : element.symbol; // number-to-symbol
+
+  const allAnswers =
+    type === "symbol-to-name"
+      ? elements.map((e) => e.name)
+      : elements.map((e) => e.symbol);
+
+  const distractors = new Set();
+  while (distractors.size < 3) {
+    distractors.add(pickRandom(allAnswers, correctAnswer));
+  }
+
+  const options = [...distractors, correctAnswer].sort(() => Math.random() - 0.5);
+
+  let prompt;
+  if (type === "symbol-to-name") {
+    prompt = `What element has the symbol "${element.symbol}"?`;
+  } else if (type === "name-to-symbol") {
+    prompt = `What is the chemical symbol for ${element.name}?`;
+  } else {
+    prompt = `What is the symbol for the element with atomic number ${element.number}?`;
+  }
+
+  return { prompt, options, correctAnswer, element };
+}
+
+const QuizMode = ({ onClose }) => {
+  const [question, setQuestion] = useState(() => generateQuestion(elementsData));
+  const [selected, setSelected] = useState(null);
+  const [score, setScore] = useState(0);
+  const [total, setTotal] = useState(0);
+  const [streak, setStreak] = useState(0);
+  const [bestStreak, setBestStreak] = useState(0);
+  const nextBtnRef = useRef(null);
+
+  const isAnswered = selected !== null;
+  const isCorrect = selected === question.correctAnswer;
+
+  const handleSelect = useCallback(
+    (option) => {
+      if (isAnswered) return;
+      setSelected(option);
+      const correct = option === question.correctAnswer;
+      setTotal((t) => t + 1);
+      if (correct) {
+        setScore((s) => s + 1);
+        setStreak((s) => {
+          const next = s + 1;
+          setBestStreak((b) => Math.max(b, next));
+          return next;
+        });
+      } else {
+        setStreak(0);
+      }
+    },
+    [isAnswered, question.correctAnswer]
+  );
+
+  const handleNext = useCallback(() => {
+    setQuestion(generateQuestion(elementsData));
+    setSelected(null);
+  }, []);
+
+  // Keyboard support: 1-4 to pick option, Enter/Space for Next
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        if (isAnswered) {
+          e.preventDefault();
+          handleNext();
+        }
+        return;
+      }
+      const idx = ["1", "2", "3", "4"].indexOf(e.key);
+      if (idx !== -1 && !isAnswered) handleSelect(question.options[idx]);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isAnswered, handleNext, handleSelect, question.options]);
+
+  // Auto-focus Next button after answering for easy keyboard flow
+  useEffect(() => {
+    if (isAnswered) nextBtnRef.current?.focus();
+  }, [isAnswered]);
+
+  const accuracy = total === 0 ? 0 : Math.round((score / total) * 100);
+
+  return (
+    <div className="quiz-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-label="Quiz Mode">
+      <div className="quiz-modal" onClick={(e) => e.stopPropagation()}>
+        {/* Header */}
+        <div className="quiz-header">
+          <h2 className="quiz-title">⚗️ Quiz Mode</h2>
+          <button className="quiz-close-btn" onClick={onClose} aria-label="Close quiz">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Score bar */}
+        <div className="quiz-scorebar">
+          <div className="quiz-score-item">
+            <span className="quiz-score-label">Score</span>
+            <span className="quiz-score-value">{score}/{total}</span>
+          </div>
+          <div className="quiz-score-item">
+            <span className="quiz-score-label">Accuracy</span>
+            <span className="quiz-score-value">{accuracy}%</span>
+          </div>
+          <div className="quiz-score-item">
+            <span className="quiz-score-label">Streak</span>
+            <span className="quiz-score-value quiz-score-streak">🔥 {streak}</span>
+          </div>
+          <div className="quiz-score-item">
+            <span className="quiz-score-label">Best</span>
+            <span className="quiz-score-value">{bestStreak}</span>
+          </div>
+        </div>
+
+        {/* Question */}
+        <div className="quiz-question">{question.prompt}</div>
+
+        {/* Element preview chip */}
+        <div className="quiz-element-chip">
+          <span className="quiz-chip-number">#{question.element.number}</span>
+          <span className="quiz-chip-symbol">{question.element.symbol}</span>
+          <span className="quiz-chip-name">{question.element.name}</span>
+        </div>
+
+        {/* Options */}
+        <div className="quiz-options">
+          {question.options.map((option, idx) => {
+            let cls = "quiz-option";
+            if (isAnswered) {
+              if (option === question.correctAnswer) cls += " correct";
+              else if (option === selected) cls += " wrong";
+            }
+            return (
+              <button
+                key={option}
+                className={cls}
+                onClick={() => handleSelect(option)}
+                disabled={isAnswered}
+                aria-label={`Option ${idx + 1}: ${option}`}
+              >
+                <span className="quiz-option-key">{idx + 1}</span>
+                <span className="quiz-option-text">{option}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Feedback + Next */}
+        {isAnswered && (
+          <div className={`quiz-feedback ${isCorrect ? "feedback-correct" : "feedback-wrong"}`}>
+            {isCorrect ? "✅ Correct!" : `❌ The answer was "${question.correctAnswer}"`}
+          </div>
+        )}
+
+        <button
+          ref={nextBtnRef}
+          className="quiz-next-btn"
+          onClick={handleNext}
+          disabled={!isAnswered}
+        >
+          Next Question →
+        </button>
+        <p className="quiz-hint">Tip: Press 1–4 to answer · Enter / Space for next</p>
+      </div>
+    </div>
+  );
+};
+
+export default QuizMode;

--- a/src/Components/SearchBar.js
+++ b/src/Components/SearchBar.js
@@ -31,6 +31,24 @@ const SearchBar = ({ elements, onSearch, onSelectElement }) => {
     onSearch(query);
   }, [query, elements, onSearch]);
 
+  // Global keyboard shortcut: "/" to focus, "Escape" to blur
+  useEffect(() => {
+    const handleGlobalKeyDown = (e) => {
+      const tag = document.activeElement?.tagName?.toLowerCase();
+      const isEditable = tag === "input" || tag === "textarea" || document.activeElement?.isContentEditable;
+
+      if (e.key === "/" && !isEditable) {
+        e.preventDefault();
+        inputRef.current?.focus();
+      } else if (e.key === "Escape" && document.activeElement === inputRef.current) {
+        inputRef.current?.blur();
+        setShowSuggestions(false);
+      }
+    };
+    document.addEventListener("keydown", handleGlobalKeyDown);
+    return () => document.removeEventListener("keydown", handleGlobalKeyDown);
+  }, []);
+
   // Close suggestions when clicking outside
   useEffect(() => {
     const handleClickOutside = (e) => {

--- a/src/Components/SearchBar.js
+++ b/src/Components/SearchBar.js
@@ -131,7 +131,7 @@ const SearchBar = ({ elements, onSearch, onSelectElement }) => {
           ref={inputRef}
           id="element-search-input"
           type="text"
-          placeholder="Search by name, symbol, or atomic number..."
+          placeholder="Press (/) to search by name, symbol, or atomic number..."
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}


### PR DESCRIPTION
# NSoC'26
# 🔁 Pull Request 

## 📌 Description
 four enhancements to the Periodic Table Explorer:

- Element Image in Details Panel — Display the real-world photo of an element when a user clicks on it.
- Extended Element Properties — Show additional data fields (melting point, boiling point, appearance, electron affinity, spectral image, Wikipedia link) in the details card.
- Keyboard Shortcut to Focus Search (/) — Press / anywhere on the page to instantly focus the search bar.
- Quiz / Flashcard Mode — An interactive quiz that tests users on element names, symbols, and atomic numbers using data already in the app.

## 🔗 Related Issue
Fixes #35

## 🚀 Type of Change
- [ ] Bug Fix  
- [x] Feature  
- [x] Enhancement  
- [ ] Documentation  

## ✅ Checklist
- [x] Code follows guidelines  
- [x] Tested properly  
- [x] Docs updated  
- [x] PR title includes **NSoC'26**

---

Implementation Screenshots:
<img width="1918" height="960" alt="Screenshot from 2026-04-26 12-56-04" src="https://github.com/user-attachments/assets/58ae8149-97b1-4670-8ac0-33748c50df6c" />
<img width="1918" height="960" alt="Screenshot from 2026-04-26 12-56-11" src="https://github.com/user-attachments/assets/73f89a2a-d34f-40ae-840b-2780a7836079" />
<img width="1918" height="960" alt="Screenshot from 2026-04-26 13-01-34" src="https://github.com/user-attachments/assets/1a286d08-e558-4b92-8eac-223761905511" />
