### PR TITLE
feat: Enhance Element Comparison Tool with Table Layout and Diff Highlighting

### DIFF
--- a/src/Components/compareElements.css
+++ b/src/Components/compareElements.css
@@ -1,43 +1,217 @@
+/* overall wrapper for the compare page */
 .compare-section {
   text-align: center;
   margin-top: 40px;
+  padding: 20px;
 }
 
-.compare-section select {
-  padding: 10px;
-  margin: 10px;
-  border-radius: 8px;
-  border: 1px solid #ccc;
-  cursor: pointer;
+.compare-title {
+  font-size: 2rem;
+  margin-bottom: 8px;
 }
 
-.compare-container {
+.compare-subtitle {
+  color: #888;
+  margin-bottom: 30px;
+  font-size: 0.95rem;
+}
+
+/* the two dropdowns and the VS badge between them */
+.compare-selectors {
   display: flex;
   justify-content: center;
-  gap: 25px;
-  margin-top: 25px;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-bottom: 30px;
+}
+
+.selector-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.selector-wrapper label {
+  font-weight: bold;
+  font-size: 0.9rem;
+  color: #aaa;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.compare-selectors select {
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font-size: 1rem;
+  cursor: pointer;
+  min-width: 200px;
+  backdrop-filter: blur(8px);
+  transition: border 0.2s;
+}
+
+.compare-selectors select:focus {
+  outline: none;
+  border-color: #7c3aed;
+}
+
+/* the VS circle between the two dropdowns */
+.vs-badge {
+  font-size: 1.4rem;
+  font-weight: 900;
+  color: #7c3aed;
+  padding: 10px 14px;
+  border-radius: 50%;
+  border: 2px solid #7c3aed;
+  line-height: 1;
+  margin-top: 22px;
+}
+
+/* element header cards shown above the table */
+.compare-header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 30px;
+  margin-bottom: 30px;
   flex-wrap: wrap;
 }
 
-.compare-card {
-  background: rgba(255, 255, 255, 0.1); /* slight glass effect */
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  padding: 20px;
-  border-radius: 15px;
-  width: 220px;
-  backdrop-filter: blur(10px);
-  margin-bottom: 20px;
+.element-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px 30px;
+  border-radius: 16px;
+  min-width: 130px;
+  opacity: 0.9;
 }
 
-.compare-card:hover {
-  transform: translateY(-5px);
+.element-symbol {
+  font-size: 2.5rem;
+  font-weight: 900;
+  color: #fff;
 }
 
-.compare-card h3 {
-  margin-bottom: 10px;
+.element-name {
+  font-size: 1rem;
+  color: #ffffffcc;
+  margin-top: 4px;
 }
 
-.highlight {
-  color: green;
-  font-weight: bold;
+.element-number {
+  font-size: 0.85rem;
+  color: #ffffff99;
+  margin-top: 2px;
+}
+
+.compare-icon {
+  font-size: 2rem;
+}
+
+/* one color per block type — used for the element header badges */
+:root {
+  --color-s: #e74c3c;
+  --color-p: #2ecc71;
+  --color-d: #3498db;
+  --color-f: #9b59b6;
+}
+
+.compare-wrapper {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+/* scrollable on smaller screens */
+.compare-table-wrapper {
+  overflow-x: auto;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.compare-table thead tr {
+  background: rgba(124, 58, 237, 0.3);
+}
+
+.compare-table th {
+  padding: 14px 20px;
+  font-weight: 700;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.compare-table td {
+  padding: 12px 20px;
+  text-align: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+/* middle column showing the property name */
+.property-label {
+  font-weight: 600;
+  color: #aaa;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+
+.value-cell {
+  font-weight: 500;
+}
+
+/* yellow highlight for rows where the two elements differ */
+.row-different {
+  background: rgba(234, 179, 8, 0.08);
+}
+
+.row-different .value-cell {
+  color: #f59e0b;
+  font-weight: 700;
+}
+
+.compare-table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+/* small note below the table */
+.compare-hint {
+  margin-top: 16px;
+  font-size: 0.85rem;
+  color: #888;
+}
+
+/* shown before the user selects both elements */
+.compare-placeholder {
+  margin-top: 60px;
+  color: #666;
+  font-size: 1.1rem;
+}
+
+/* mobile adjustments */
+@media (max-width: 600px) {
+  .compare-table th,
+  .compare-table td {
+    padding: 10px 12px;
+    font-size: 0.85rem;
+  }
+
+  .element-badge {
+    padding: 14px 20px;
+    min-width: 100px;
+  }
+
+  .element-symbol {
+    font-size: 2rem;
+  }
 }

--- a/src/Components/compareElements.js
+++ b/src/Components/compareElements.js
@@ -1,58 +1,128 @@
 import React, { useState } from "react";
-import elementsData from "../Data/elementsData"; // adjust path if needed
+import elementsData from "../Data/elementsData";
 import "./compareElements.css";
+
+// all the properties we want to show in the comparison table
+const properties = [
+  { label: "Atomic Number", key: "number" },
+  { label: "Atomic Mass", key: "atomic_mass" },
+  { label: "Group", key: "group" },
+  { label: "Period", key: "period" },
+  { label: "Block", key: "block" },
+  { label: "Phase", key: "phase" },
+  { label: "Electronegativity", key: "electronegativity_pauling" },
+  { label: "Density (g/L)", key: "density" },
+  { label: "Melting Point (K)", key: "melt" },
+  { label: "Boiling Point (K)", key: "boil" },
+  { label: "Discovered By", key: "discovered_by" },
+  { label: "Category", key: "category" },
+];
 
 function CompareElements() {
   const [el1, setEl1] = useState("");
   const [el2, setEl2] = useState("");
 
-  const element1 = elementsData.find(e => e.symbol === el1);
-  const element2 = elementsData.find(e => e.symbol === el2);
+  // find the full element object from the symbol the user picked
+  const element1 = elementsData.find((e) => e.symbol === el1);
+  const element2 = elementsData.find((e) => e.symbol === el2);
+
+  // returns true if the two elements have different values for a given property
+  // used to highlight rows where they differ
+  const isDifferent = (key) => {
+    if (!element1 || !element2) return false;
+    return element1[key] !== element2[key];
+  };
 
   return (
     <div className="compare-section">
-  <h2>Compare Elements</h2>
+      <h2 className="compare-title">⚗️ Compare Elements</h2>
+      <p className="compare-subtitle">Select two elements to compare their properties side by side</p>
 
-  <select onChange={(e) => setEl1(e.target.value)}>
-    <option>Select Element 1</option>
-    {elementsData.map(el => (
-      <option key={el.symbol} value={el.symbol}>
-        {el.name}
-      </option>
-    ))}
-  </select>
+      {/* dropdowns to pick the two elements */}
+      <div className="compare-selectors">
+        <div className="selector-wrapper">
+          <label>Element 1</label>
+          <select onChange={(e) => setEl1(e.target.value)} value={el1}>
+            <option value="">Select Element</option>
+            {elementsData.map((el) => (
+              <option key={el.symbol} value={el.symbol}>
+                {el.name} ({el.symbol})
+              </option>
+            ))}
+          </select>
+        </div>
 
-  <select onChange={(e) => setEl2(e.target.value)}>
-    <option>Select Element 2</option>
-    {elementsData.map(el => (
-      <option key={el.symbol} value={el.symbol}>
-        {el.name}
-      </option>
-    ))}
-  </select>
+        <div className="vs-badge">VS</div>
 
-  {element1 && element2 && (
-    <div className="compare-container">
-
-      <div className="compare-card">
-        <h3>{element1.name}</h3>
-        <p>Atomic Mass: {element1.atomic_mass}</p>
-        <p>Electronegativity: {element1.electronegativity_pauling ?? "N/A"}</p>
-        <p>Density: {element1.density ?? "N/A"}</p>
-        <p>Boiling Point: {element1.boil ?? "N/A"} K</p>
+        <div className="selector-wrapper">
+          <label>Element 2</label>
+          <select onChange={(e) => setEl2(e.target.value)} value={el2}>
+            <option value="">Select Element</option>
+            {elementsData.map((el) => (
+              <option key={el.symbol} value={el.symbol}>
+                {el.name} ({el.symbol})
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
 
-      <div className="compare-card">
-        <h3>{element2.name}</h3>
-        <p>Atomic Mass: {element2.atomic_mass}</p>
-        <p>Electronegativity: {element2.electronegativity_pauling ?? "N/A"}</p>
-        <p>Density: {element2.density ?? "N/A"}</p>
-        <p>Boiling Point: {element2.boil ?? "N/A"} K</p>
-      </div>
+      {/* only show the comparison once both elements are selected */}
+      {element1 && element2 && (
+        <div className="compare-wrapper">
 
+          {/* header showing the two element symbols with their block color */}
+          <div className="compare-header">
+            <div className="element-badge" style={{ background: `var(--color-${element1.block})` }}>
+              <span className="element-symbol">{element1.symbol}</span>
+              <span className="element-name">{element1.name}</span>
+              <span className="element-number">#{element1.number}</span>
+            </div>
+
+            <div className="compare-icon">⚡</div>
+
+            <div className="element-badge" style={{ background: `var(--color-${element2.block})` }}>
+              <span className="element-symbol">{element2.symbol}</span>
+              <span className="element-name">{element2.name}</span>
+              <span className="element-number">#{element2.number}</span>
+            </div>
+          </div>
+
+          {/* main comparison table — rows turn yellow when the values are different */}
+          <div className="compare-table-wrapper">
+            <table className="compare-table">
+              <thead>
+                <tr>
+                  <th>{element1.name}</th>
+                  <th>Property</th>
+                  <th>{element2.name}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {properties.map(({ label, key }) => (
+                  <tr key={key} className={isDifferent(key) ? "row-different" : "row-same"}>
+                    <td className="value-cell">{element1[key] ?? "N/A"}</td>
+                    <td className="property-label">{label}</td>
+                    <td className="value-cell">{element2[key] ?? "N/A"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="compare-hint">
+            🟡 Highlighted rows indicate differences between the two elements
+          </p>
+        </div>
+      )}
+
+      {/* placeholder shown before the user picks both elements */}
+      {(!element1 || !element2) && (
+        <div className="compare-placeholder">
+          <p>👆 Select two elements above to see their comparison</p>
+        </div>
+      )}
     </div>
-  )}
-</div>
   );
 }
 


### PR DESCRIPTION
Closes #62 

### What changed
- Added 12 properties to the comparison table (was only 4 before)
- Replaced card layout with a clean side-by-side table
- Rows that differ between elements are highlighted in yellow
- Added element header badges with block-based colors (s/p/d/f)
- Added VS badge between the two dropdowns
- Added placeholder message before elements are selected
- Made the table responsive for mobile screens

### How to test
1. Go to the Compare Elements section
2. Select any two elements from the dropdowns
3. The table shows all properties side by side
4. Different values are highlighted in yellow